### PR TITLE
Added URL delegate function to handle openURL functionality

### DIFF
--- a/Sources/ObjCSources/GleapCore.h
+++ b/Sources/ObjCSources/GleapCore.h
@@ -30,6 +30,7 @@ typedef enum surveyFormat { SURVEY, SURVEY_FULL } GleapSurveyFormat;
 - (void) widgetClosed;
 - (void) registerPushMessageGroup: (NSString *)pushMessageGroup;
 - (void) unregisterPushMessageGroup: (NSString *)pushMessageGroup;
+- (void) openExternalLink: (NSURL *)url;
 @required
 @end
 

--- a/Sources/ObjCSources/GleapFrameManagerViewController.m
+++ b/Sources/ObjCSources/GleapFrameManagerViewController.m
@@ -294,7 +294,11 @@
         if ([name isEqualToString: @"open-url"] && messageData != nil) {
             UIViewController *presentingViewController = self.presentingViewController;
             [self closeWidget:^{
-                [self openURLExternally: [NSURL URLWithString: (NSString *)messageData] fromViewController: presentingViewController];
+                if (Gleap.sharedInstance.delegate && [Gleap.sharedInstance.delegate respondsToSelector: @selector(openExternalLink:)]) {
+                    [Gleap.sharedInstance.delegate openExternalLink: [NSURL URLWithString: (NSString *)messageData]];
+                } else {
+                    [self openURLExternally: [NSURL URLWithString: (NSString *)messageData] fromViewController: presentingViewController];
+                }
             }];
         }
         


### PR DESCRIPTION
In this pull request, I have added a URL delegate function to the existing codebase. This delegate function allows the client app to handle the openURL action with customized logic.

The code checks if the Gleap shared instance has a delegate and if the delegate responds to the `openExternalLink:` selector. If the delegate exists and responds to the selector, it calls the delegate's `openExternalLink:` method with the provided URL. This allows the client app to handle the external link in a customized way.

If the delegate does not exist or does not respond to the selector, the code falls back to the `openURLExternally`