### PR TITLE
Forward window motions events

### DIFF
--- a/Sources/ObjCSources/UIWindow+GleapShakeRecognizer.h
+++ b/Sources/ObjCSources/UIWindow+GleapShakeRecognizer.h
@@ -11,6 +11,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSNotificationName const WindowDidBeginMotionNotification;
+extern NSNotificationName const WindowDidEndMotionNotification;
+
+extern NSString * const WindowMotionEventUserInfoKey;
+extern NSString * const WindowMotionEventSubtypeUserInfoKey;
+
 @interface UIWindow (GleapShakeRecognizer)
 
 @end

--- a/Sources/ObjCSources/UIWindow+GleapShakeRecognizer.m
+++ b/Sources/ObjCSources/UIWindow+GleapShakeRecognizer.m
@@ -11,7 +11,31 @@
 
 @implementation UIWindow (GleapShakeRecognizer)
 
+NSNotificationName const WindowDidBeginMotionNotification = @"WindowDidBeginMotionNotification";
+NSNotificationName const WindowDidEndMotionNotification = @"WindowDidEndMotionNotification";
+
+NSString * const WindowMotionEventUserInfoKey = @"WindowMotionEventUserInfoKey";
+NSString * const WindowMotionEventSubtypeUserInfoKey = @"WindowMotionEventSubtypeUserInfoKey";
+
+- (void)motionBegan:(UIEventSubtype)motion withEvent:(UIEvent *)event {
+    NSDictionary *userInfo = @{
+        WindowMotionEventUserInfoKey: event,
+        WindowMotionEventSubtypeUserInfoKey: [NSNumber numberWithInteger: motion]
+    };
+    [[NSNotificationCenter defaultCenter] postNotificationName: WindowDidBeginMotionNotification
+                                                        object: nil
+                                                      userInfo: userInfo];
+}
+
 - (void)motionEnded:(UIEventSubtype)motion withEvent:(UIEvent *)event {
+    NSDictionary *userInfo = @{
+        WindowMotionEventUserInfoKey: event,
+        WindowMotionEventSubtypeUserInfoKey: [NSNumber numberWithInteger: motion]
+    };
+    [[NSNotificationCenter defaultCenter] postNotificationName: WindowDidEndMotionNotification
+                                                        object: nil
+                                                      userInfo: userInfo];
+
     if (motion == UIEventSubtypeMotionShake) {
         [Gleap shakeInvocation];
     }


### PR DESCRIPTION
To catch the shake gesture, the Gleap SDK overrides the `motionEnded:withEvent:` method of `UIWindow`.
This prevents the embedding app from doing the same and catching the shake event as well, even if the Gleap's shake invocation is disabled.

In this PR, the Gleap SDK still overrides the method, but posts a notification that can then be caught by the app. As this method doesn't only apply to the shake event, the original event and its subtype are embedded in the notification's `userInfo`.
For consistency, the same is done for the matching `motionBegan:withEvent:` method.
This doesn't change the way the shake gesture is handled by the SDK.

I know this is not necessarily the responsibility of the Gleap SDK to send these notifications, but the only other way I see for catching this gesture without that would be to swizzle the `motionEnded:withEvent:` method, and this would prevent the shake invocation from working at all.